### PR TITLE
Tell git that .breq is text, not binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.breq text


### PR DESCRIPTION
This will make GitHub treat .breq as a text, not binary, which will make subsequent PRs understandable.
